### PR TITLE
v0.4.2 - Metadata Hotfix

### DIFF
--- a/.github/releases/v0.4.2.md
+++ b/.github/releases/v0.4.2.md
@@ -1,0 +1,1 @@
+This release fixes an issue that resulting in package failure if templates did not have a metadata section.

--- a/src/TemplatePackager.cs
+++ b/src/TemplatePackager.cs
@@ -155,10 +155,15 @@ namespace Cythral.CloudFormation.BuildTasks
             {
                 var doc = (YamlMappingNode)yamlStream.Documents[0].RootNode;
                 var resources = (YamlMappingNode)doc.Children["Resources"];
-                var metadata = (YamlMappingNode)doc.Children["Metadata"];
                 var children = new List<KeyValuePair<YamlNode, YamlNode>>();
                 children.AddRange(resources);
-                children.AddRange(metadata);
+
+                doc.Children.TryGetValue("Metadata", out var metadata);
+
+                if (metadata != null && metadata is YamlMappingNode metadataMappingNode)
+                {
+                    children.AddRange(metadataMappingNode);
+                }
 
                 foreach (var resource in children)
                 {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publicReleaseRefSpec": ["^refs/tags/v\\d\\.\\d"]
 }


### PR DESCRIPTION
This release fixes an issue that resulting in package failure if templates did not have a metadata section.