### PR TITLE
Automatic update of NUnit3TestAdapter to 3.17.0

### DIFF
--- a/tests/BuildTasksTests.csproj
+++ b/tests/BuildTasksTests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="nunit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     </ItemGroup>
 

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -96,9 +96,9 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[3.15.1, )",
-        "resolved": "3.15.1",
-        "contentHash": "gqy0llGjhJYq9ebFvtbmBcF/MY8z5kcTIxYs+eXwp2d4Ntha8pSPxUzryvBm7H46VbWI6FS5/XNbxwiQpe88vQ==",
+        "requested": "[3.17.0, )",
+        "resolved": "3.17.0",
+        "contentHash": "I9MNvK+GM2yXrHPitwZkAZKU9sYI2OO/8wKC+VuBD7V3z+ySQ1pSopX/urr0ooedI8/TIcajYPRO4vGRr7AM8A==",
         "dependencies": {
           "Microsoft.DotNet.InternalAbstractions": "1.0.0",
           "System.ComponentModel.EventBasedAsync": "4.3.0",


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit3TestAdapter` to `3.17.0` from `3.15.1`
`NUnit3TestAdapter 3.17.0` was published at `2020-07-11T19:10:58Z`, 7 months ago

1 project update:
Updated `tests/BuildTasksTests.csproj` to `NUnit3TestAdapter` `3.17.0` from `3.15.1`

[NUnit3TestAdapter 3.17.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/3.17.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
