### PR TITLE
Automatic update of YamlDotNet to 9.1.4

### DIFF
--- a/src/BuildTasks.csproj
+++ b/src/BuildTasks.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -89,9 +89,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[8.1.2, )",
-        "resolved": "8.1.2",
-        "contentHash": "GlPKbb4l+91dyYVKV7UnJlr2CWooNNM1ayZWC90QAmlFPgbwSkfhgId7dGjTAHqkB84BZqjMSy5PlAYf1iejVA=="
+        "requested": "[9.1.4, )",
+        "resolved": "9.1.4",
+        "contentHash": "dVVZVhQxTI4xTNc9YorE+RruBFPPYKP44kMijE6Z5OQQE7zK+SEmh2sPm091CrTYVz1jjIuXKIBm1kFLrlsQJg=="
       },
       "AWSSDK.Core": {
         "type": "Transitive",


### PR DESCRIPTION
NuKeeper has generated a major update of `YamlDotNet` to `9.1.4` from `8.1.2`
`YamlDotNet 9.1.4` was published at `2021-01-15T17:21:37Z`, 18 days ago

1 project update:
Updated `src/BuildTasks.csproj` to `YamlDotNet` `9.1.4` from `8.1.2`

[YamlDotNet 9.1.4 on NuGet.org](https://www.nuget.org/packages/YamlDotNet/9.1.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
