### PR TITLE
Automatic update of Microsoft.CodeAnalysis.FxCopAnalyzers to 3.3.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,48 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-    <PropertyGroup>
-        <Authors>Talen Fisher</Authors>
-        <Company>Cythral LLC</Company>
-        <Copyright>© Copyright 2020 Cythral LLC</Copyright>
-        <PackageProjectUrl>https://github.com/cythral/cfn-build-tasks</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/cythral/cfn-build-tasks</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-        <PackageTags>AWS Amazon Cloud CloudFormation MSBuild</PackageTags>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <Configuration Condition="$(Configuration) == ''">Debug</Configuration>
-        <Nullable>enable</Nullable>
-        <LangVersion>9.0</LangVersion>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-        <RestoreLockedMode Condition="$(IGNORE_LOCK_FILES) != 'true'">true</RestoreLockedMode>
-        <OutputPath>$(MSBuildThisFileDirectory)bin\$(MSBuildProjectName)\$(Configuration)</OutputPath>
-        <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-        <PackageOutputPath>$(MSBuildThisFileDirectory)bin\Packages\$(Configuration)</PackageOutputPath>
-        <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
-        <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
-    </ItemGroup>
-
-    <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)\.editorconfig')">
-        <AdditionalFiles Include="$(MSBuildThisFileDirectory)\.editorconfig" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
-    </ItemGroup>
+  <PropertyGroup>
+    <Authors>Talen Fisher</Authors>
+    <Company>Cythral LLC</Company>
+    <Copyright>© Copyright 2020 Cythral LLC</Copyright>
+    <PackageProjectUrl>https://github.com/cythral/cfn-build-tasks</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cythral/cfn-build-tasks</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageTags>AWS Amazon Cloud CloudFormation MSBuild</PackageTags>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition="$(Configuration) == ''">Debug</Configuration>
+    <Nullable>enable</Nullable>
+    <LangVersion>9.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <RestoreLockedMode Condition="$(IGNORE_LOCK_FILES) != 'true'">true</RestoreLockedMode>
+    <OutputPath>$(MSBuildThisFileDirectory)bin\$(MSBuildProjectName)\$(Configuration)</OutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)bin\Packages\$(Configuration)</PackageOutputPath>
+    <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
+  </ItemGroup>
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)\.editorconfig')">
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\.editorconfig" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.2` from `3.3.1`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.2` was published at `2020-12-04T00:17:15Z`, 2 months ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.2` from `3.3.1`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
