### PR TITLE
Automatic update of AutoFixture.AutoNSubstitute to 4.15.0

### DIFF
--- a/tests/BuildTasksTests.csproj
+++ b/tests/BuildTasksTests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.14.0" />
+        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
         <PackageReference Include="AutoFixture.NUnit3" Version="4.14.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETCoreApp,Version=v5.0": {
       "AutoFixture.AutoNSubstitute": {
         "type": "Direct",
-        "requested": "[4.14.0, )",
-        "resolved": "4.14.0",
-        "contentHash": "/CykcrwvB6/LD1zFvYXSGKwNMSCKx71p7Rd3pSWH47y5Iz0kwgI8zyI17+CQQ4ZQ16zlZEoz+l238K1DT4a6mw==",
+        "requested": "[4.15.0, )",
+        "resolved": "4.15.0",
+        "contentHash": "fOcvdvDi6wCvp495wc7Rq7fAEnYCx6oRI1NCJoj5xbMQOMnF0+pqByrby7Rzr0Js+qd1sGNsF1QkDjir+zrMPA==",
         "dependencies": {
-          "AutoFixture": "4.14.0",
+          "AutoFixture": "4.15.0",
           "NSubstitute": "[2.0.3, 5.0.0)"
         }
       },
@@ -113,8 +113,8 @@
       },
       "AutoFixture": {
         "type": "Transitive",
-        "resolved": "4.14.0",
-        "contentHash": "Hs6Tcxd4gVZVPCNhuDccnpaBSvcbi33eIPiwAhKw+WRu5z1ClFIDamkw100oADo8Ay1HchGEBU8klwkJfCDMNg==",
+        "resolved": "4.15.0",
+        "contentHash": "TZTWBoxqCHKYob3//v5MaWuGj6rF6rLsD1V0ta20gQpzulnjT4oTnMIy05/Y5VKtyZ1D3VqcokOKMq27lWEpuQ==",
         "dependencies": {
           "Fare": "[2.1.1, 3.0.0)",
           "System.ComponentModel.Annotations": "4.3.0"


### PR DESCRIPTION
NuKeeper has generated a minor update of `AutoFixture.AutoNSubstitute` to `4.15.0` from `4.14.0`
`AutoFixture.AutoNSubstitute 4.15.0` was published at `2020-12-18T16:13:15Z`, 2 months ago

1 project update:
Updated `tests/BuildTasksTests.csproj` to `AutoFixture.AutoNSubstitute` `4.15.0` from `4.14.0`

[AutoFixture.AutoNSubstitute 4.15.0 on NuGet.org](https://www.nuget.org/packages/AutoFixture.AutoNSubstitute/4.15.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
