### PR TITLE
Automatic update of AutoFixture.NUnit3 to 4.15.0

### DIFF
--- a/tests/BuildTasksTests.csproj
+++ b/tests/BuildTasksTests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.14.0" />
-        <PackageReference Include="AutoFixture.NUnit3" Version="4.14.0" />
+        <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="nunit" Version="3.12.0" />

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -14,11 +14,11 @@
       },
       "AutoFixture.NUnit3": {
         "type": "Direct",
-        "requested": "[4.14.0, )",
-        "resolved": "4.14.0",
-        "contentHash": "5m1sxG3VgRnj/nJnoG77kP0b+aeIw+dXdPPqFbmgQBAIeObsHqsEAQxEUP/8VyFlJAWA+jJ+Lh2SMaXEZiMvaQ==",
+        "requested": "[4.15.0, )",
+        "resolved": "4.15.0",
+        "contentHash": "55i2i+wb5PFo0JDlJt99ZaFfuNA9YXVLpT1WNOhx3cN+8K4GBA+0/LHFTUAUYiE+bRC5FYSJkaHa8ceS0ypZtA==",
         "dependencies": {
-          "AutoFixture": "4.14.0",
+          "AutoFixture": "4.15.0",
           "NUnit": "[3.7.0, 4.0.0)"
         }
       },
@@ -113,8 +113,8 @@
       },
       "AutoFixture": {
         "type": "Transitive",
-        "resolved": "4.14.0",
-        "contentHash": "Hs6Tcxd4gVZVPCNhuDccnpaBSvcbi33eIPiwAhKw+WRu5z1ClFIDamkw100oADo8Ay1HchGEBU8klwkJfCDMNg==",
+        "resolved": "4.15.0",
+        "contentHash": "TZTWBoxqCHKYob3//v5MaWuGj6rF6rLsD1V0ta20gQpzulnjT4oTnMIy05/Y5VKtyZ1D3VqcokOKMq27lWEpuQ==",
         "dependencies": {
           "Fare": "[2.1.1, 3.0.0)",
           "System.ComponentModel.Annotations": "4.3.0"


### PR DESCRIPTION
NuKeeper has generated a minor update of `AutoFixture.NUnit3` to `4.15.0` from `4.14.0`
`AutoFixture.NUnit3 4.15.0` was published at `2020-12-18T16:13:20Z`, 2 months ago

1 project update:
Updated `tests/BuildTasksTests.csproj` to `AutoFixture.NUnit3` `4.15.0` from `4.14.0`

[AutoFixture.NUnit3 4.15.0 on NuGet.org](https://www.nuget.org/packages/AutoFixture.NUnit3/4.15.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
