### PR TITLE
Automatic update of NUnit to 3.13.1

### DIFF
--- a/tests/BuildTasksTests.csproj
+++ b/tests/BuildTasksTests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
-        <PackageReference Include="nunit" Version="3.12.0" />
+        <PackageReference Include="nunit" Version="3.13.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     </ItemGroup>

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -87,9 +87,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[3.12.0, )",
-        "resolved": "3.12.0",
-        "contentHash": "3oJTrcUcT9wmweBUwgUf0f1XIYy6RZq2ziV+RM95HMKAJGsHPN2i3MKK1dAPvDPMRLz799Llj4eyu/STB9Q7OA==",
+        "requested": "[3.13.1, )",
+        "resolved": "3.13.1",
+        "contentHash": "vWBvrSelmTYwqHWvO3dA63z7cOpaFR/3nJ9MMVLBkWeaWa7oiglPPm5g1h96B4i2XXqjFexxhR5MyMjmIJYPfg==",
         "dependencies": {
           "NETStandard.Library": "2.0.0"
         }
@@ -1089,8 +1089,8 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "8.1.2",
-        "contentHash": "GlPKbb4l+91dyYVKV7UnJlr2CWooNNM1ayZWC90QAmlFPgbwSkfhgId7dGjTAHqkB84BZqjMSy5PlAYf1iejVA=="
+        "resolved": "9.1.4",
+        "contentHash": "dVVZVhQxTI4xTNc9YorE+RruBFPPYKP44kMijE6Z5OQQE7zK+SEmh2sPm091CrTYVz1jjIuXKIBm1kFLrlsQJg=="
       },
       "Cythral.CloudFormation.BuildTasks": {
         "type": "Project",
@@ -1100,7 +1100,7 @@
           "Microsoft.Build.Framework": "16.8.0",
           "Microsoft.Build.Utilities.Core": "16.8.0",
           "System.Runtime.Loader": "4.3.0",
-          "YamlDotNet": "8.1.2"
+          "YamlDotNet": "9.1.4"
         }
       }
     }


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit` to `3.13.1` from `3.12.0`
`NUnit 3.13.1` was published at `2021-02-01T01:29:59Z`, 2 days ago

1 project update:
Updated `tests/BuildTasksTests.csproj` to `NUnit` `3.13.1` from `3.12.0`

[NUnit 3.13.1 on NuGet.org](https://www.nuget.org/packages/NUnit/3.13.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
