### PR TITLE
Automatic update of AWSSDK.S3 to 3.5.8

### DIFF
--- a/src/BuildTasks.csproj
+++ b/src/BuildTasks.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.8" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -13,11 +13,11 @@
       },
       "AWSSDK.S3": {
         "type": "Direct",
-        "requested": "[3.5.0, )",
-        "resolved": "3.5.0",
-        "contentHash": "CLlXO0FGY8CnzBJGyVrLAi4rTDYaNUzbitEZ6B7qvnVRUOG8HnWS3KU7nk/wm6fJVTpa+CSHoittUzHfZbY2+g==",
+        "requested": "[3.5.8, )",
+        "resolved": "3.5.8",
+        "contentHash": "5S/EXknQmUjK7mE5fR32CnIWTNa8ySFQgE3Jq3MRLXPajvALK1Zz5nX1JP1zQd8IE4Q12OTyJKKxgnjyp5nMDg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.0, 3.6.0)"
+          "AWSSDK.Core": "[3.5.2.4, 3.6.0)"
         }
       },
       "Microsoft.Build.Framework": {
@@ -95,8 +95,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.0",
-        "contentHash": "bC5slbW3f1QgYlJK/I/zDUlixHq8YzktTwreJHwoOCpnRFB/IHV4EIgdEGwQnWOneJwRfwq4ZB0OhlrM3aT2pw=="
+        "resolved": "3.5.2.4",
+        "contentHash": "dm3hMqJieiySx1sVTtr+7r2BuAKQErySbU8t90uQ7tWpQCboHSigez8A5V4IuAEcAofkzMDXnKh3sIqV53iKzQ=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -130,15 +130,15 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "3.5.0",
-        "contentHash": "bC5slbW3f1QgYlJK/I/zDUlixHq8YzktTwreJHwoOCpnRFB/IHV4EIgdEGwQnWOneJwRfwq4ZB0OhlrM3aT2pw=="
+        "resolved": "3.5.2.4",
+        "contentHash": "dm3hMqJieiySx1sVTtr+7r2BuAKQErySbU8t90uQ7tWpQCboHSigez8A5V4IuAEcAofkzMDXnKh3sIqV53iKzQ=="
       },
       "AWSSDK.S3": {
         "type": "Transitive",
-        "resolved": "3.5.0",
-        "contentHash": "CLlXO0FGY8CnzBJGyVrLAi4rTDYaNUzbitEZ6B7qvnVRUOG8HnWS3KU7nk/wm6fJVTpa+CSHoittUzHfZbY2+g==",
+        "resolved": "3.5.8",
+        "contentHash": "5S/EXknQmUjK7mE5fR32CnIWTNa8ySFQgE3Jq3MRLXPajvALK1Zz5nX1JP1zQd8IE4Q12OTyJKKxgnjyp5nMDg==",
         "dependencies": {
-          "AWSSDK.Core": "[3.5.0, 3.6.0)"
+          "AWSSDK.Core": "[3.5.2.4, 3.6.0)"
         }
       },
       "Castle.Core": {
@@ -1089,18 +1089,18 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "8.1.2",
-        "contentHash": "GlPKbb4l+91dyYVKV7UnJlr2CWooNNM1ayZWC90QAmlFPgbwSkfhgId7dGjTAHqkB84BZqjMSy5PlAYf1iejVA=="
+        "resolved": "9.1.4",
+        "contentHash": "dVVZVhQxTI4xTNc9YorE+RruBFPPYKP44kMijE6Z5OQQE7zK+SEmh2sPm091CrTYVz1jjIuXKIBm1kFLrlsQJg=="
       },
       "Cythral.CloudFormation.BuildTasks": {
         "type": "Project",
         "dependencies": {
           "AWSSDK.CloudFormation": "3.5.0",
-          "AWSSDK.S3": "3.5.0",
+          "AWSSDK.S3": "3.5.8",
           "Microsoft.Build.Framework": "16.8.0",
           "Microsoft.Build.Utilities.Core": "16.8.0",
           "System.Runtime.Loader": "4.3.0",
-          "YamlDotNet": "8.1.2"
+          "YamlDotNet": "9.1.4"
         }
       }
     }


### PR DESCRIPTION
NuKeeper has generated a patch update of `AWSSDK.S3` to `3.5.8` from `3.5.0`
`AWSSDK.S3 3.5.8` was published at `2021-02-02T23:22:11Z`, 16 hours ago

1 project update:
Updated `src/BuildTasks.csproj` to `AWSSDK.S3` `3.5.8` from `3.5.0`

[AWSSDK.S3 3.5.8 on NuGet.org](https://www.nuget.org/packages/AWSSDK.S3/3.5.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
